### PR TITLE
Update ExpoAndroidCheckInstalledAppsModule.swift

### DIFF
--- a/ios/ExpoAndroidCheckInstalledAppsModule.swift
+++ b/ios/ExpoAndroidCheckInstalledAppsModule.swift
@@ -31,5 +31,19 @@ public class ExpoAndroidCheckInstalledAppsModule: Module {
         "value": value
       ])
     }
+
+    AsyncFunction("checkAppsInstalled") { (packageNames: [String], promise: Promise) in
+       var result: [String: Bool] = [:]
+
+       for packageName in packageNames {
+         if let url = URL(string: packageName), UIApplication.shared.canOpenURL(url) {
+           result[packageName] = true 
+         } else {
+           result[packageName] = false 
+         }
+       }
+
+       promise.resolve(result)
+     }
   }
 }


### PR DESCRIPTION

```
// javasciprt example

    const packageNames = Platform.select({
      android: [
        'com.google.android.apps.fitness',
        'com.focusbear',
        'com.android.chrome',
      ],
      ios: [
        'fb://',
        'twitter://',
        'instagram://',
        'whatsapp://',
        'youtube://',
      ],
    });

//info.plist

<key>LSApplicationQueriesSchemes</key>
<array>
    <string>fb</string>
    <string>twitter</string>
    <string>instagram</string>
    <string>whatsapp</string>
    <string>youtube</string>
</array>

```

I have added the implementation since iOS is not included. Please review. 

