### PR TITLE
check if package query already exist to avoid dupe qeuries

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -36,8 +36,15 @@ const withAndroid: ConfigPlugin<PluginOptions> = (config, { android }) => {
       package: newPackages,
     };
 
-    // Append the new <queries> block while preserving existing blocks
-    manifest.queries.push(newQueriesBlock);
+    // Check if the new query block already exists
+    const queryExists = manifest.queries.some(
+      (query) => JSON.stringify(query) === JSON.stringify(newQueriesBlock)
+    );
+
+    if (!queryExists) {
+      // Append the new <queries> block while preserving existing blocks
+      manifest.queries.push(newQueriesBlock);
+    }
 
     return config;
   });


### PR DESCRIPTION
This adds a check if the query already exists in the AndroidManifest file, I do not have an iOS so I was unable to test it there.